### PR TITLE
Fix configuration cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,10 +15,11 @@ kotlin {
     wasmJs {
         binaries.executable()
         browser {
+            val projectDirPath = project.projectDir.path
             commonWebpackConfig {
                 devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
                     static = (static ?: mutableListOf()).apply {
-                        add(project.rootDir.path)
+                        add(projectDirPath)
                     }
                 }
             }


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-69751/wasmJsTest-tasks-not-compatible-with-Gradle-configuration-cache#focus=Comments-27-10110132.0-0